### PR TITLE
Synopsys: Automated PR: Update Blackduck Vulnerable Components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
 	<name>Insecure Bank</name>
 	<!-- Adding a comment-->
 	<properties>
-		<org.springframework-version>4.2.3.RELEASE</org.springframework-version>
-		<org.spring-security-version>4.0.3.RELEASE</org.spring-security-version>
+		<org.springframework-version>4.2.5.RELEASE</org.springframework-version>
+		<org.spring-security-version>4.2.20</org.spring-security-version>
 		<org.slf4j-version>1.7.13</org.slf4j-version>
 		<jaxb.version>2.3.0</jaxb.version>
         	<activation.version>1.1.1</activation.version>
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
-			<version>5.3.0.Final</version>
+			<version>5.6.15.Final-redhat-00001</version>
 		</dependency>
 		<!-- Database -->
 		<dependency>
@@ -182,7 +182,7 @@
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<version>2.3.4</version>
+			<version>2.7.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-dbcp</groupId>
@@ -214,13 +214,13 @@
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
+			<version>1.2.17.norce</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.3.3</version>
+			<version>1.5</version>
 		</dependency>
 		<!-- Spring Security -->
 		<dependency>


### PR DESCRIPTION
## Vulnerable components in this MR/PR
### *CRITICAL:* Update org.springframework:spring-web:4.2.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2022-0858](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0858) *(CRITICAL)*: Spring Framework is vulnerable to a flaw in the access restrictions to the security sensitive `ClassLoader` property. The restrictions can be bypassed through alternative paths available with Java9 and later. An attacker can leverage this vulnerability to cause remote code execution (RCE).

**Note** this issue exists because the restrictions that were introduced to prevent exploitation of BDSA-2010-0001 (CVE-2010-1622) can be bypassed on platforms where Java9 and later are in use.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[BDSA-2018-1042](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1042) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages. Original remediation was not implemented correctly for the 4.3.x branch.

[BDSA-2016-1700](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1700) *(HIGH)*: Pivotal's Spring Framework contains an unsafe Java deserialization vulnerability. If the Spring Framework library's `HttpInvokerServiceExporter` is being used to deserialize client data, it may be possible for a remote attacker to perform remote code execution (RCE) on systems using Spring Framework.

**Note:** All versions prior to **6.0.0-M1** (Which is a pre-release) contain the functionality that may lead to deserialization attacks depending on how the library is implemented in the product.

[BDSA-2018-0994](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-0994) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages.

[BDSA-2022-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0847) *(HIGH)*: Software systems using Spring Framework may be vulnerable to unsafe deserialization if they employ unsafe use of certain provided deserialization functionality. A remote attacker could potentially execute arbitrary code on a vulnerable endpoint by passing a maliciously crafted serialized object to that endpoint.

**Note**: This issue only affects software that has been written to leverage specific deserialization functionality provided by the Spring Framework without sanitization.

[BDSA-2016-0002](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-0002) *(HIGH)*: Spring Framework is vulnerable to path traversal. Paths provided to the `Resourceservlet` were not properly sanitized and as a result exposed to directory traversal attacks. `ResourceServlet` is now deprecated and `ResourceHttpRequestHandler` (and related classes) have superseded it.

[BDSA-2024-0402](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-0402) *(HIGH)*: Spring Framework is vulnerable to server-side request forgery (SSRF) and an open redirect attack. An attacker could send a crafted HTTP request and deceive the application into making requests to unintended systems. This could enable an attacker to access confidential information or send harmful requests to other servers from the compromised system.

[BDSA-2018-1440](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1440) *(MEDIUM)*: Spring Framework has a flaw in the manipulation of regular expressions within the spring-messaging module. An attacker can send a specially crafted message to the simple STOMP broker that will trigger a regular expression denial-of-service (ReDoS).

[BDSA-2018-1901](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1901) *(MEDIUM)*: Spring Framework is vulnerable to information exposure due to improper configuration of JSON with Padding (JSONP). This could allow an attacker to obtain potentially sensitive information.

[BDSA-2018-1960](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1960) *(MEDIUM)*: A cross-site tracing (*XST*) vulnerability has been discovered in spring framework. The application allows obscure request methods, such as TRACE and TRACK. These HTTP methods can be used with an existing cross-site scripting (*XSS*) vulnerability to escalate to an XST vulnerability. An attacker could exploit this by utilizing an XSS vulnerability to bypass cookie protection and steal sensitive data.

[BDSA-2023-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0847) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions.

[BDSA-2020-2431](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-2431) *(MEDIUM)*: It was discovered that Spring Framework was vulnerable to RFD protection bypass. In some instances, depending on the browser used, an attacker could bypass the RFD attack protections via the use of a `jsessionid` path parameter.

[BDSA-2021-3236](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3236) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: a follow-up to this issue was disclosed as **CVE-2021-22060** (**BDSA-2021-3236**), with further fixed releases that protect against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2022-0011](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0011) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: the vendor states this issue exists as a follow up to CVE-2021-22096 (BDSA-2022-0011) that protects against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2022-0820](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0820) *(MEDIUM)*: Spring-Framework's spring-expression is vulnerable to a denial-of-service (DoS) condition. This allows an attacker to use crafted input to cause the spring-expression process to crash due to an exception.

[BDSA-2018-1013](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1013) *(MEDIUM)*: Spring Framework is vulnerable to directory traversal due to the way static content can be loaded. Potential attackers could leverage this flaw to gain unauthorized access to sensitive files on Windows hosts.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2023-0638](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0638) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions. An attacker could exploit this issue by passing a crafted SpEL expression to the application which may result in a crash.

[BDSA-2018-3577](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-3577) *(MEDIUM)*: An improper input validation vulnerability has been discovered in Spring Framework by Pivotal. A range header input is not being correctly restricted allowing a high value to be accepted by the application. An attacker could exploit this vulnerability to cause a denial-of-service (DoS) condition. 

This vulnerability affects applications that depend on either `spring-webmvc` or `spring-webflux`.

[BDSA-2022-1040](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1040) *(LOW)*: Spring Framework is vulnerable to data binding protection bypass due to improper validation of specified disallowed fields in `DataBinders`. This could be leveraged by an attacker to bypass the suggested workaround to **CVE-2022-22965** (**BDSA-2022-0858**) if it is improperly implemented.

[BDSA-2018-1016](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1016) *(LOW)*: Spring Framework is vulnerable to privilege escalation due to insufficient validation of user-supplied input. Crafted input from a remote client can be used to exploit a flaw in the way that servers running the affected software communicate with each other. This is because communication between the servers uses that user-supplied input for building requests.

### *CRITICAL:* Update org.springframework:spring-jdbc:4.2.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2022-0858](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0858) *(CRITICAL)*: Spring Framework is vulnerable to a flaw in the access restrictions to the security sensitive `ClassLoader` property. The restrictions can be bypassed through alternative paths available with Java9 and later. An attacker can leverage this vulnerability to cause remote code execution (RCE).

**Note** this issue exists because the restrictions that were introduced to prevent exploitation of BDSA-2010-0001 (CVE-2010-1622) can be bypassed on platforms where Java9 and later are in use.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[BDSA-2016-1700](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1700) *(HIGH)*: Pivotal's Spring Framework contains an unsafe Java deserialization vulnerability. If the Spring Framework library's `HttpInvokerServiceExporter` is being used to deserialize client data, it may be possible for a remote attacker to perform remote code execution (RCE) on systems using Spring Framework.

**Note:** All versions prior to **6.0.0-M1** (Which is a pre-release) contain the functionality that may lead to deserialization attacks depending on how the library is implemented in the product.

[BDSA-2018-1042](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1042) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages. Original remediation was not implemented correctly for the 4.3.x branch.

[BDSA-2022-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0847) *(HIGH)*: Software systems using Spring Framework may be vulnerable to unsafe deserialization if they employ unsafe use of certain provided deserialization functionality. A remote attacker could potentially execute arbitrary code on a vulnerable endpoint by passing a maliciously crafted serialized object to that endpoint.

**Note**: This issue only affects software that has been written to leverage specific deserialization functionality provided by the Spring Framework without sanitization.

[BDSA-2018-0994](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-0994) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages.

[BDSA-2024-0402](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-0402) *(HIGH)*: Spring Framework is vulnerable to server-side request forgery (SSRF) and an open redirect attack. An attacker could send a crafted HTTP request and deceive the application into making requests to unintended systems. This could enable an attacker to access confidential information or send harmful requests to other servers from the compromised system.

[BDSA-2016-0002](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-0002) *(HIGH)*: Spring Framework is vulnerable to path traversal. Paths provided to the `Resourceservlet` were not properly sanitized and as a result exposed to directory traversal attacks. `ResourceServlet` is now deprecated and `ResourceHttpRequestHandler` (and related classes) have superseded it.

[BDSA-2018-1013](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1013) *(MEDIUM)*: Spring Framework is vulnerable to directory traversal due to the way static content can be loaded. Potential attackers could leverage this flaw to gain unauthorized access to sensitive files on Windows hosts.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2023-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0847) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions.

[BDSA-2023-0638](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0638) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions. An attacker could exploit this issue by passing a crafted SpEL expression to the application which may result in a crash.

[BDSA-2021-3236](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3236) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: a follow-up to this issue was disclosed as **CVE-2021-22060** (**BDSA-2021-3236**), with further fixed releases that protect against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2022-0011](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0011) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: the vendor states this issue exists as a follow up to CVE-2021-22096 (BDSA-2022-0011) that protects against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2018-1440](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1440) *(MEDIUM)*: Spring Framework has a flaw in the manipulation of regular expressions within the spring-messaging module. An attacker can send a specially crafted message to the simple STOMP broker that will trigger a regular expression denial-of-service (ReDoS).

[BDSA-2018-1901](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1901) *(MEDIUM)*: Spring Framework is vulnerable to information exposure due to improper configuration of JSON with Padding (JSONP). This could allow an attacker to obtain potentially sensitive information.

[BDSA-2018-1960](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1960) *(MEDIUM)*: A cross-site tracing (*XST*) vulnerability has been discovered in spring framework. The application allows obscure request methods, such as TRACE and TRACK. These HTTP methods can be used with an existing cross-site scripting (*XSS*) vulnerability to escalate to an XST vulnerability. An attacker could exploit this by utilizing an XSS vulnerability to bypass cookie protection and steal sensitive data.

[BDSA-2018-3577](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-3577) *(MEDIUM)*: An improper input validation vulnerability has been discovered in Spring Framework by Pivotal. A range header input is not being correctly restricted allowing a high value to be accepted by the application. An attacker could exploit this vulnerability to cause a denial-of-service (DoS) condition. 

This vulnerability affects applications that depend on either `spring-webmvc` or `spring-webflux`.

[BDSA-2020-2431](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-2431) *(MEDIUM)*: It was discovered that Spring Framework was vulnerable to RFD protection bypass. In some instances, depending on the browser used, an attacker could bypass the RFD attack protections via the use of a `jsessionid` path parameter.

[BDSA-2022-0820](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0820) *(MEDIUM)*: Spring-Framework's spring-expression is vulnerable to a denial-of-service (DoS) condition. This allows an attacker to use crafted input to cause the spring-expression process to crash due to an exception.

[BDSA-2018-1016](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1016) *(LOW)*: Spring Framework is vulnerable to privilege escalation due to insufficient validation of user-supplied input. Crafted input from a remote client can be used to exploit a flaw in the way that servers running the affected software communicate with each other. This is because communication between the servers uses that user-supplied input for building requests.

[BDSA-2022-1040](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1040) *(LOW)*: Spring Framework is vulnerable to data binding protection bypass due to improper validation of specified disallowed fields in `DataBinders`. This could be leveraged by an attacker to bypass the suggested workaround to **CVE-2022-22965** (**BDSA-2022-0858**) if it is improperly implemented.

### *CRITICAL:* Update org.springframework:spring-webmvc:4.2.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2022-0858](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0858) *(CRITICAL)*: Spring Framework is vulnerable to a flaw in the access restrictions to the security sensitive `ClassLoader` property. The restrictions can be bypassed through alternative paths available with Java9 and later. An attacker can leverage this vulnerability to cause remote code execution (RCE).

**Note** this issue exists because the restrictions that were introduced to prevent exploitation of BDSA-2010-0001 (CVE-2010-1622) can be bypassed on platforms where Java9 and later are in use.

This vulnerability is listed as exploitable by the Cybersecurity & Infrastructure Security Agency in their [Known Exploited Vulnerabilities Catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).

[BDSA-2018-1042](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1042) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages. Original remediation was not implemented correctly for the 4.3.x branch.

[BDSA-2016-1700](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1700) *(HIGH)*: Pivotal's Spring Framework contains an unsafe Java deserialization vulnerability. If the Spring Framework library's `HttpInvokerServiceExporter` is being used to deserialize client data, it may be possible for a remote attacker to perform remote code execution (RCE) on systems using Spring Framework.

**Note:** All versions prior to **6.0.0-M1** (Which is a pre-release) contain the functionality that may lead to deserialization attacks depending on how the library is implemented in the product.

[BDSA-2018-0994](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-0994) *(HIGH)*: Spring Framework is vulnerable to remote code execution (RCE) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target system by sending crafted messages.

[BDSA-2022-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0847) *(HIGH)*: Software systems using Spring Framework may be vulnerable to unsafe deserialization if they employ unsafe use of certain provided deserialization functionality. A remote attacker could potentially execute arbitrary code on a vulnerable endpoint by passing a maliciously crafted serialized object to that endpoint.

**Note**: This issue only affects software that has been written to leverage specific deserialization functionality provided by the Spring Framework without sanitization.

[BDSA-2016-0002](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-0002) *(HIGH)*: Spring Framework is vulnerable to path traversal. Paths provided to the `Resourceservlet` were not properly sanitized and as a result exposed to directory traversal attacks. `ResourceServlet` is now deprecated and `ResourceHttpRequestHandler` (and related classes) have superseded it.

[BDSA-2024-0402](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-0402) *(HIGH)*: Spring Framework is vulnerable to server-side request forgery (SSRF) and an open redirect attack. An attacker could send a crafted HTTP request and deceive the application into making requests to unintended systems. This could enable an attacker to access confidential information or send harmful requests to other servers from the compromised system.

[BDSA-2018-1440](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1440) *(MEDIUM)*: Spring Framework has a flaw in the manipulation of regular expressions within the spring-messaging module. An attacker can send a specially crafted message to the simple STOMP broker that will trigger a regular expression denial-of-service (ReDoS).

[BDSA-2018-1901](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1901) *(MEDIUM)*: Spring Framework is vulnerable to information exposure due to improper configuration of JSON with Padding (JSONP). This could allow an attacker to obtain potentially sensitive information.

[BDSA-2018-1960](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1960) *(MEDIUM)*: A cross-site tracing (*XST*) vulnerability has been discovered in spring framework. The application allows obscure request methods, such as TRACE and TRACK. These HTTP methods can be used with an existing cross-site scripting (*XSS*) vulnerability to escalate to an XST vulnerability. An attacker could exploit this by utilizing an XSS vulnerability to bypass cookie protection and steal sensitive data.

[BDSA-2023-0847](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0847) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions.

[BDSA-2020-2431](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-2431) *(MEDIUM)*: It was discovered that Spring Framework was vulnerable to RFD protection bypass. In some instances, depending on the browser used, an attacker could bypass the RFD attack protections via the use of a `jsessionid` path parameter.

[BDSA-2021-3236](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3236) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: a follow-up to this issue was disclosed as **CVE-2021-22060** (**BDSA-2021-3236**), with further fixed releases that protect against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2022-0011](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0011) *(MEDIUM)*: Spring Framework is vulnerable to log file injection due to the insufficient validation of user input in an undisclosed component. An attacker could leverage this issue in order to add arbitrary entries to a log file which could impact both the integrity issues and performance issues.

**Note**: the vendor states this issue exists as a follow up to CVE-2021-22096 (BDSA-2022-0011) that protects against additional types of input and in more places of the Spring Framework codebase.

[BDSA-2022-0820](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0820) *(MEDIUM)*: Spring-Framework's spring-expression is vulnerable to a denial-of-service (DoS) condition. This allows an attacker to use crafted input to cause the spring-expression process to crash due to an exception.

[BDSA-2018-1013](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1013) *(MEDIUM)*: Spring Framework is vulnerable to directory traversal due to the way static content can be loaded. Potential attackers could leverage this flaw to gain unauthorized access to sensitive files on Windows hosts.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2023-0638](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0638) *(MEDIUM)*: Spring Framework is vulnerable to denial-of-service (DoS) via specially crafted SpEL expressions. An attacker could exploit this issue by passing a crafted SpEL expression to the application which may result in a crash.

[BDSA-2018-3577](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-3577) *(MEDIUM)*: An improper input validation vulnerability has been discovered in Spring Framework by Pivotal. A range header input is not being correctly restricted allowing a high value to be accepted by the application. An attacker could exploit this vulnerability to cause a denial-of-service (DoS) condition. 

This vulnerability affects applications that depend on either `spring-webmvc` or `spring-webflux`.

[BDSA-2022-1040](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1040) *(LOW)*: Spring Framework is vulnerable to data binding protection bypass due to improper validation of specified disallowed fields in `DataBinders`. This could be leveraged by an attacker to bypass the suggested workaround to **CVE-2022-22965** (**BDSA-2022-0858**) if it is improperly implemented.

[BDSA-2018-1016](https://openhub.net/vulnerabilities/bdsa/BDSA-2018-1016) *(LOW)*: Spring Framework is vulnerable to privilege escalation due to insufficient validation of user-supplied input. Crafted input from a remote client can be used to exploit a flaw in the way that servers running the affected software communicate with each other. This is because communication between the servers uses that user-supplied input for building requests.

### *CRITICAL:* Update log4j:log4j:1.2.17 to 4.2.5.RELEASE 
[BDSA-2019-4008](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-4008) *(CRITICAL)*: Apache Log4j is vulnerable to remote code execution (RCE).  This allows a remote attacker to send a crafted serialized payload that, when processed by Log4j, will execute arbitrary code. This can occur if Log4j is deserializing untrusted network traffic.

[BDSA-2022-0117](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0117) *(HIGH)*: Log4j is vulnerable to remote code execution (RCE) due to the deserialization of untrusted data. An attacker that is able to make the JMSSink component submit requests to a given LDAP server could load malicious Java classes into the vulnerable application's memory by leveraging the JNDI class-loading capability.

In order to exploit this vulnerability, the attacker must be able to control the configuration of Log4j, or must have access to an LDAP server which the JMSSink component is configured to use. Log4j must also be configured to utilize JMSSink, which is not used by default.

[BDSA-2022-0118](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0118) *(HIGH)*: Apache Log4j is vulnerable to a remote code execution (RCE) issue due to how the Apache Chainsaw component can unsafely deserialize user controlled input.

An attacker could send crafted input to the application in order to abuse the flaw and execute malicious code on the system.

**Note**: The Apache Chainsaw deserialization vulnerability has been reported as **CVE-2020-9493** and affects EOL Apache Log4j **1.2.x** versions that include this component.

[BDSA-2021-3764](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-3764) *(HIGH)*: Log4j **1.x** versions are vulnerable to deserializing untrusted data if configured to use `JMSAppender` (which is not the default). A remote attacker could leverage this to execute arbitrary code on the underlying system with the privileges of the application that is running Log4j.

**Note** that Log4j **1.x** has been marked EOL for many years and has not received updates in this time.

[BDSA-2021-4371](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-4371) *(HIGH)*: Apache chainsaw is vulnerable to a deserialization of untrusted data flaw. A remote attacker could leverage this to cause remote code execution (RCE).

[BDSA-2022-0119](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-0119) *(MEDIUM)*: Apache Log4j **1.2.x** versions are vulnerable to SQL injection (SQLi). This may allow an attacker to insert SQL queries into messages being logged that will get executed against a backend database. 

**Note:** This issue  affects versions **1.2.x** that are configured to use the `JDBCAppender`. The vendor states that Log4j 1 is no longer maintained and this issue will not be fixed.

[BDSA-2020-1398](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-1398) *(MEDIUM)*: Apache Log4j is vulnerable to man-in-the-middle (MITM) attacks due to improper SSL certificate validation due to host name mismatch. An attacker could exploit this by mounting a man-in-the-middle attack which could leak log messages sent through SMTPS.

### *HIGH:* Update org.springframework.security:spring-security-core:4.0.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2016-1603](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1603) *(HIGH)*: Spring Security contains a path traversal vulnerability. This could be exploited by a remote attacker to bypass security constraints when handling URL path parameters.

[BDSA-2022-1369](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1369) *(HIGH)*: Spring Security is vulnerable to the bypassing of an authorization mechanism due to improperly implemented regular expression matching. A remote attacker could perform unauthorized actions on a vulnerable server by sending maliciously crafted requests to that server.

[BDSA-2022-3109](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-3109) *(HIGH)*: Spring Security contains a flaw when dealing with OAuth2 access token empty scope list  responses. A remote attacker could leverage this to escalate their privileges under **all** the following conditions being met:

* They act as the role of a Login Client (e.g. uses `http.oauth2Login()`).
* They use one or more authorization rules with authorities mapped from authorized scopes (e.g. `anyRequest().hasAuthority("SCOPE_message.write")`) in the client application.
* An authorization server that responds with empty scopes list is registered (RFC 6749, Section 5.1).

**Note:** The role of Resource Servers (`http.oauth2ResourceServer()`) and applications that do not map authorization rules from authorized scopes (eg. `anyRequest().hasAuthority("ROLE_USER")`) cannot be exploited by this vulnerability.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2019-1853](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-1853) *(MEDIUM)*: Spring Security contains a vulnerability that allows authentication bypass. An attacker could exploit this to gain unauthorized access to the application.

[BDSA-2021-0417](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0417) *(MEDIUM)*: Spring Security is vulnerable to privilege escalation due to a failure to correctly save security context information. An attacker who is allowed to use elevated privileges in a small portion of a program could extend those privileges to the entire program by sending maliciously crafted requests to the application.

It should be noted that the vulnerability is not present by default, and must be programmed in by an application developer.

[BDSA-2021-2310](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2310) *(MEDIUM)*: Spring Security contains an uncontrolled resource consumption vulnerability. Attackers could exploit this to create an `OutOfMemory` error and exhaust  system resources, triggering a denial-of-service (DoS) condition.

[BDSA-2022-1370](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1370) *(MEDIUM)*: Spring Security is vulnerable to the weakening of bcrypt-generated password hashes due to an integer overflow. An attacker that is able to obtain weak password hashes that have been produced by a vulnerable application could potentially retrieve the plaintext password. It should be noted that the `BCryptPasswordEncoder` class must have been configured to use the maximum work factor (31) in order for the vulnerability to manifest. This is a non-default value.

### *HIGH:* Update org.springframework.security:spring-security-web:4.0.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2016-1603](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1603) *(HIGH)*: Spring Security contains a path traversal vulnerability. This could be exploited by a remote attacker to bypass security constraints when handling URL path parameters.

[BDSA-2022-1369](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1369) *(HIGH)*: Spring Security is vulnerable to the bypassing of an authorization mechanism due to improperly implemented regular expression matching. A remote attacker could perform unauthorized actions on a vulnerable server by sending maliciously crafted requests to that server.

[BDSA-2022-3109](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-3109) *(HIGH)*: Spring Security contains a flaw when dealing with OAuth2 access token empty scope list  responses. A remote attacker could leverage this to escalate their privileges under **all** the following conditions being met:

* They act as the role of a Login Client (e.g. uses `http.oauth2Login()`).
* They use one or more authorization rules with authorities mapped from authorized scopes (e.g. `anyRequest().hasAuthority("SCOPE_message.write")`) in the client application.
* An authorization server that responds with empty scopes list is registered (RFC 6749, Section 5.1).

**Note:** The role of Resource Servers (`http.oauth2ResourceServer()`) and applications that do not map authorization rules from authorized scopes (eg. `anyRequest().hasAuthority("ROLE_USER")`) cannot be exploited by this vulnerability.

[BDSA-2021-2310](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2310) *(MEDIUM)*: Spring Security contains an uncontrolled resource consumption vulnerability. Attackers could exploit this to create an `OutOfMemory` error and exhaust  system resources, triggering a denial-of-service (DoS) condition.

[BDSA-2022-1370](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1370) *(MEDIUM)*: Spring Security is vulnerable to the weakening of bcrypt-generated password hashes due to an integer overflow. An attacker that is able to obtain weak password hashes that have been produced by a vulnerable application could potentially retrieve the plaintext password. It should be noted that the `BCryptPasswordEncoder` class must have been configured to use the maximum work factor (31) in order for the vulnerability to manifest. This is a non-default value.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2021-0417](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0417) *(MEDIUM)*: Spring Security is vulnerable to privilege escalation due to a failure to correctly save security context information. An attacker who is allowed to use elevated privileges in a small portion of a program could extend those privileges to the entire program by sending maliciously crafted requests to the application.

It should be noted that the vulnerability is not present by default, and must be programmed in by an application developer.

[BDSA-2019-1853](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-1853) *(MEDIUM)*: Spring Security contains a vulnerability that allows authentication bypass. An attacker could exploit this to gain unauthorized access to the application.

### *HIGH:* Update org.springframework.security:spring-security-config:4.0.3.RELEASE to 4.2.5.RELEASE 
[BDSA-2016-1603](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1603) *(HIGH)*: Spring Security contains a path traversal vulnerability. This could be exploited by a remote attacker to bypass security constraints when handling URL path parameters.

[BDSA-2022-1369](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1369) *(HIGH)*: Spring Security is vulnerable to the bypassing of an authorization mechanism due to improperly implemented regular expression matching. A remote attacker could perform unauthorized actions on a vulnerable server by sending maliciously crafted requests to that server.

[BDSA-2022-3109](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-3109) *(HIGH)*: Spring Security contains a flaw when dealing with OAuth2 access token empty scope list  responses. A remote attacker could leverage this to escalate their privileges under **all** the following conditions being met:

* They act as the role of a Login Client (e.g. uses `http.oauth2Login()`).
* They use one or more authorization rules with authorities mapped from authorized scopes (e.g. `anyRequest().hasAuthority("SCOPE_message.write")`) in the client application.
* An authorization server that responds with empty scopes list is registered (RFC 6749, Section 5.1).

**Note:** The role of Resource Servers (`http.oauth2ResourceServer()`) and applications that do not map authorization rules from authorized scopes (eg. `anyRequest().hasAuthority("ROLE_USER")`) cannot be exploited by this vulnerability.

[BDSA-2016-1577](https://openhub.net/vulnerabilities/bdsa/BDSA-2016-1577) *(MEDIUM)*: The Spring Framework contains a flaw when handling URL pattern mappings. The component fails to maintain the intended authorization for mapping requests to controllers. This could allow a remote attacker to bypass authentication and read protected files.

[BDSA-2019-1853](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-1853) *(MEDIUM)*: Spring Security contains a vulnerability that allows authentication bypass. An attacker could exploit this to gain unauthorized access to the application.

[BDSA-2021-0417](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-0417) *(MEDIUM)*: Spring Security is vulnerable to privilege escalation due to a failure to correctly save security context information. An attacker who is allowed to use elevated privileges in a small portion of a program could extend those privileges to the entire program by sending maliciously crafted requests to the application.

It should be noted that the vulnerability is not present by default, and must be programmed in by an application developer.

[BDSA-2021-2310](https://openhub.net/vulnerabilities/bdsa/BDSA-2021-2310) *(MEDIUM)*: Spring Security contains an uncontrolled resource consumption vulnerability. Attackers could exploit this to create an `OutOfMemory` error and exhaust  system resources, triggering a denial-of-service (DoS) condition.

[BDSA-2022-1370](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-1370) *(MEDIUM)*: Spring Security is vulnerable to the weakening of bcrypt-generated password hashes due to an integer overflow. An attacker that is able to obtain weak password hashes that have been produced by a vulnerable application could potentially retrieve the plaintext password. It should be noted that the `BCryptPasswordEncoder` class must have been configured to use the maximum work factor (31) in order for the vulnerability to manifest. This is a non-default value.

### *HIGH:* Update org.hibernate:hibernate-core:5.3.0.Final to 4.2.5.RELEASE 
[BDSA-2020-3410](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-3410) *(HIGH)*: Hibernate ORM is vulnerable to SQL injection due to the unsafe implementation of comments that are intended for debugging purposes. A remote attacker could potentially recover, modify or delete sensitive information that resides in back-end databases by submitting crafted requests that abuse these comments. It should be noted that only instances of Hibernate ORM that use a non-default configuration are affected.

[BDSA-2019-4479](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-4479) *(MEDIUM)*: Hibernate ORM is vulnerable to SQL injection (SQLi) due to insufficient validation of user-controlled input. An attacker may be able to obtain unauthorized information from the database by executing arbitrary SQL commands.

### *HIGH:* Update org.hsqldb:hsqldb:2.3.4 to 4.2.5.RELEASE 
[BDSA-2022-3330](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-3330) *(HIGH)*: HyperSQL DataBase is vulnerable to remote code execution (RCE) due to improper input validation thus allowing unsafe reflection. An authenticated attacker could exploit this by supplying a crafted input to potentially execute code on the application.

### *MEDIUM:* Update commons-fileupload:commons-fileupload:1.3.3 to 4.2.5.RELEASE 
[BDSA-2023-0357](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-0357) *(MEDIUM)*: Apache Commons FileUpload does not sufficiently limit the the number of request parts that can be received via user input. An attacker can exploit this flaw by supplying a malicious upload or series of uploads and cause excessive resource allocation. This can trigger a denial-of-service (DoS).

**Note:** This vulnerability was not properly fixed in Apache Tomcat and required an additional disclosure as **CVE-2023-28709** (**BDSA-2023-1242**). The fix for Apache Commons FileUpload was not affected.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/d6f777f0-8bbd-467a-89aa-a70e92ef8eb4/versions/00fecd88-61e2-4662-b9fd-d624f6fb8ea1/vulnerability-bom)